### PR TITLE
Fix for methods like `is_compressed()` not working.

### DIFF
--- a/sqliteanalyzer/storageanalyzer.py
+++ b/sqliteanalyzer/storageanalyzer.py
@@ -240,9 +240,7 @@ class StorageAnalyzer:
                                             FROM sqlite_master
                                             WHERE rootpage>0
                                               AND type == "table"''')
-        # Why include sqlite_master if it doesn't hold usage data?
-        # -JL
-        #return [t['name'] for t in tables] + ['sqlite_master']
+        # Do not include `sqlite_master` because it doesn't hold usage data
         return [t['name'] for t in tables]
 
     def indices(self) -> [Index]:

--- a/sqliteanalyzer/storageanalyzer.py
+++ b/sqliteanalyzer/storageanalyzer.py
@@ -240,8 +240,10 @@ class StorageAnalyzer:
                                             FROM sqlite_master
                                             WHERE rootpage>0
                                               AND type == "table"''')
-
-        return [t['name'] for t in tables] + ['sqlite_master']
+        # Why include sqlite_master if it doesn't hold usage data?
+        # -JL
+        #return [t['name'] for t in tables] + ['sqlite_master']
+        return [t['name'] for t in tables]
 
     def indices(self) -> [Index]:
         """Returns the indices defined in the database.
@@ -319,8 +321,8 @@ class StorageAnalyzer:
         """Returns whether the database file is compressed."""
         if self._is_compressed is None:
             table = self.tables().pop()
-            self._iscompresed = self.table_stats(table)['is_compressed']
-        return self._iscompresed
+            self._is_compressed = self.table_stats(table)['is_compressed']
+        return self._is_compressed
 
     def autovacuum_page_count(self) -> int:
         """The number of pages used by the *auto-vacuum*


### PR DESCRIPTION
Anything that tries to work with usage data for the `sqlite_master` virtual table would fail, as it returns None for quantity values.

This pull requests corrects that by leaving `sqlite_master` out of the list of tables returned by the `.tables()` method.

I also fixed an error where the value for the `is_compressed()` method would never cache.